### PR TITLE
Modified to support draft-js@0.6.0

### DIFF
--- a/src/draft-utils/add-block.js
+++ b/src/draft-utils/add-block.js
@@ -11,7 +11,7 @@ export default function (editorState, selection, type, data, asJson) {
     else if (asJson) {
         editorState = EditorState.push(
             EditorState.createEmpty(decorator),
-            ContentState.createFromBlockArray(convertFromRaw(editorState))
+            convertFromRaw(editorState)
         );
     }
 

--- a/src/draft-utils/remove-block.js
+++ b/src/draft-utils/remove-block.js
@@ -16,6 +16,6 @@ export default function(editorState, key){
     // Workaround, removeRange removed entity, but not the block
     var rawContent = convertToRaw(afterRemoval);
     rawContent.blocks = rawContent.blocks.filter(x=>x.key !== block.getKey());
-    var newState = EditorState.push(editorState, ContentState.createFromBlockArray(convertFromRaw(rawContent)), 'remove-range');
+    var newState = EditorState.push(editorState, convertFromRaw(rawContent), 'remove-range');
     return newState;
 }

--- a/src/draft.js
+++ b/src/draft.js
@@ -14,7 +14,7 @@ export default class DraftWysiwyg extends Component {
       var value = EditorState.createEmpty(decorator);
       if (props.value) {
          this.__raw = props.value;
-         value = EditorState.push(value, ContentState.createFromBlockArray(convertFromRaw(props.value)));
+         value = EditorState.push(value, convertFromRaw(props.value));
       }
 
       // Set value to state
@@ -32,7 +32,7 @@ export default class DraftWysiwyg extends Component {
          this.setState({
             value: !props.value
                 ? EditorState.createEmpty(decorator)
-                : EditorState.push(this.state.value, ContentState.createFromBlockArray(convertFromRaw(props.value)))
+                : EditorState.push(this.state.value, convertFromRaw(props.value))
          });
          return false;
       }


### PR DESCRIPTION
convertFromRaw now returns a ContentState object instead of an Array<ContentBlock>, so where we were previously doing ContentState.createFromBlockArray(convertFromRaw(<RawValue>)) to create a ContentState we can now just do convertFromRaw(<RawValue>).
