### PR TITLE
Adding plugins configuration option + block toolbar configuration option

### DIFF
--- a/example/container.js
+++ b/example/container.js
@@ -95,6 +95,33 @@ export default class Example extends React.Component {
 
         return (
             <div className="flex-container">
+              <div className="head">
+                    <div className="logo">Draft-Wysiwyg</div>
+                    <a className="github-button" href="https://github.com/bkniffler/draft-wysiwyg/" target="_blank">
+                        View on Github
+                    </a>
+                    <button className={"button"+(view==='json'?' active':'')} onClick={()=>this.setState({view: 'json'})}>
+                        See JSON
+                    </button>
+                    <button className={"button"+(view==='edit'?' active':'')} onClick={()=>this.setState({view: 'edit'})}>
+                        See Editor
+                    </button>
+                    <button className="button" onClick={::this.save}>
+                        {saved ? 'Saved!' : 'Save to localstorage'}
+                    </button>
+                    <button className="button" onClick={(v)=>this.setState({data:null})}>
+                        Clear
+                    </button>
+                    {/*<button className="button" onClick={()=>this.setState({data: Draft.AddBlock(data, 'end', 'div', {}, true)})}>
+                        Horizontal+Vertical
+                    </button>
+                    <button className="button" onClick={()=>this.setState({data: Draft.AddBlock(data, 'start', 'div2', {}, true)})}>Add
+                        Horizontal only
+                    </button>
+                    <button className="button" onClick={()=>this.setState({data: Draft.AddBlock(data, 'start', 'youtube', {}, true)})}>Add
+                        Youtube
+                    </button>*/}
+                </div>
                 {this.renderSide()}
                 <div className="container-content" style={{display: view==='json' ? 'block' : 'none'}}>
                     <pre style={{whiteSpace: 'pre-wrap', width: '750px', margin: 'auto'}}>{JSON.stringify(data, null, 3)}</pre>

--- a/example/container.js
+++ b/example/container.js
@@ -1,9 +1,9 @@
 import React from 'react';
-
+import { RichUtils } from 'draft-js';
 import Editor from '../src';
 import { Blocks, Data } from './draft';
 import request from 'superagent';
-
+import createToolbarPlugin from 'draft-js-toolbar-plugin';
 export default class Example extends React.Component {
     constructor(props) {
         super(props);
@@ -62,7 +62,7 @@ export default class Example extends React.Component {
                 success(res.body.files, 'image');
             });
     }
-    
+
     defaultData = (blockType) => {
         if (blockType === 'block-image') {
             return {
@@ -90,38 +90,11 @@ export default class Example extends React.Component {
            </div>
        )
     }
-    render() { 
+    render() {
         const {data, view, saved} = this.state;
-        
+
         return (
             <div className="flex-container">
-                <div className="head">
-                    <div className="logo">Draft-Wysiwyg</div>
-                    <a className="github-button" href="https://github.com/bkniffler/draft-wysiwyg/" target="_blank">
-                        View on Github
-                    </a>
-                    <button className={"button"+(view==='json'?' active':'')} onClick={()=>this.setState({view: 'json'})}>
-                        See JSON
-                    </button>
-                    <button className={"button"+(view==='edit'?' active':'')} onClick={()=>this.setState({view: 'edit'})}>
-                        See Editor
-                    </button>
-                    <button className="button" onClick={::this.save}>
-                        {saved ? 'Saved!' : 'Save to localstorage'}
-                    </button>
-                    <button className="button" onClick={(v)=>this.setState({data:null})}>
-                        Clear
-                    </button>
-                    {/*<button className="button" onClick={()=>this.setState({data: Draft.AddBlock(data, 'end', 'div', {}, true)})}>
-                        Horizontal+Vertical
-                    </button>
-                    <button className="button" onClick={()=>this.setState({data: Draft.AddBlock(data, 'start', 'div2', {}, true)})}>Add
-                        Horizontal only
-                    </button>
-                    <button className="button" onClick={()=>this.setState({data: Draft.AddBlock(data, 'start', 'youtube', {}, true)})}>Add
-                        Youtube
-                    </button>*/}
-                </div>
                 {this.renderSide()}
                 <div className="container-content" style={{display: view==='json' ? 'block' : 'none'}}>
                     <pre style={{whiteSpace: 'pre-wrap', width: '750px', margin: 'auto'}}>{JSON.stringify(data, null, 3)}</pre>
@@ -129,13 +102,26 @@ export default class Example extends React.Component {
                 <div className="container-content" style={{display: view!=='json' ? 'block' : 'none'}}>
                     <div className="TeXEditor-root">
                         <div className="TeXEditor-editor">
-                            <Editor onChange={data=>this.setState({data})} 
-                                    value={data} 
-                                    blockTypes={Blocks} 
-                                    cleanupTypes="*" 
-                                    sidebar={0} 
+                            <Editor onChange={data=>this.setState({data})}
+                                    value={data}
+                                    blockTypes={Blocks}
+                                    cleanupTypes="*"
+                                    sidebar={0}
                                     handleDefaultData={this.defaultData}
-                                    handleUpload={this.upload}/>
+                                    handleUpload={this.upload}
+                                    toolbar={{
+                                      disableItems: ['H5'],
+                                      textActions: [
+                                      {
+                                        button: <span>Quote</span>,
+                                        label: 'Quote',
+                                        active: (block, editorState) => block.get('type') === 'blockquote',
+                                        toggle: (block, action, editorState, setEditorState) => setEditorState(RichUtils.toggleBlockType(
+                                          editorState,
+                                          'blockquote'
+                                        )),
+                                      }]
+                                    }}/>
                         </div>
                     </div>
                 </div>

--- a/src/create-plugins.js
+++ b/src/create-plugins.js
@@ -46,7 +46,8 @@ const table = FocusDecorator(
 );
 
 // Init Plugins
-export default ({ handleUpload, handleDefaultData }) => [
+export default ({ handleUpload, handleDefaultData, plugins = ()=>{}, toolbar = { disableItems: [], textActions: []}}) => [
+  plugins,
   createCleanupEmptyPlugin({
     types: ['block-image', 'block-table']
   }),
@@ -55,8 +56,9 @@ export default ({ handleUpload, handleDefaultData }) => [
     __toolbarHandler: {
       add: props => console.log('Add toolbar', props),
       remove: props => console.log('Remove toolbar', props),
-    }, textActions: [{
+    }, textActions: [...[{
       button: <span>H1</span>,
+      key: 'H1',
       label: 'Header 1',
       active: (block, editorState) => block.get('type') === 'header-1',
       toggle: (block, action, editorState, setEditorState) => setEditorState(RichUtils.toggleBlockType(
@@ -65,6 +67,7 @@ export default ({ handleUpload, handleDefaultData }) => [
       )),
     }, {
       button: <span>H2</span>,
+      key: 'H2',
       label: 'Header 2',
       active: (block, editorState) => block.get('type') === 'header-2',
       toggle: (block, action, editorState, setEditorState) => setEditorState(RichUtils.toggleBlockType(
@@ -73,6 +76,7 @@ export default ({ handleUpload, handleDefaultData }) => [
       )),
     }, {
       button: <span>H3</span>,
+      key: 'H3',
       label: 'Header 3',
       active: (block, editorState) => block.get('type') === 'header-3',
       toggle: (block, action, editorState, setEditorState) => setEditorState(RichUtils.toggleBlockType(
@@ -81,18 +85,23 @@ export default ({ handleUpload, handleDefaultData }) => [
       )),
     }, {
       button: <span>H4</span>,
+      key: 'H4',
       label: 'Header 4',
       active: (block, editorState) => block.get('type') === 'header-4',
       toggle: (block, action, editorState, setEditorState) => setEditorState(RichUtils.toggleBlockType(
         editorState,
         'header-4'
       )),
-    }/*, {
-      button: <span>Table</span>,
-      label: 'Create a table',
-      active: (block, editorState) => editorState.getSelection().isCollapsed(),
-      toggle: (block, action, editorState, setEditorState) => setEditorState(addBlock(editorState, editorState.getSelection(), 'block-table', {})),
-    }*/]
+    }, {
+      button: <span>H5</span>,
+      key: 'H5',
+      label: 'Header 5',
+      active: (block, editorState) => block.get('type') === 'header-4',
+      toggle: (block, action, editorState, setEditorState) => setEditorState(RichUtils.toggleBlockType(
+        editorState,
+        'header-5'
+      )),
+    }].filter(toolbarItem => !toolbar.disableItems.includes(toolbarItem.key)), ...toolbar.textActions]
   }),
   createFocusPlugin({}),
   createAlignmentPlugin({}),


### PR DESCRIPTION
Hey. Working with draftjs-wysiwyg I've noticed that block toolbar cannot be customizable through Editor props.
 I've added options to add different block toolbar buttons (see example of Quote), option to disable block toolbar items (example for H5 which is disabled) and option to pass additional plugins to the Editor.
