### PR TITLE
Update the engines section of package.json to be compatible with 6.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "repository": "https://github.com/bkniffler/draft-wysiwyg",
   "main": "./lib",
   "engines": {
-    "node": "5.x.x",
-    "npm": "3.x.x"
+    "node": ">=5.0.0",
+    "npm": ">=3.0.0"
   },
   "keywords": [
     "draftjs",


### PR DESCRIPTION
6.9.3 is LTS and current is 7.3.0 so 5.x.x has been deprecated.